### PR TITLE
location_diff: if custom field missing, don’t assume delta

### DIFF
--- a/location.go
+++ b/location.go
@@ -159,10 +159,6 @@ type Location struct {
 	*/
 }
 
-func (y Location) GetNilIsEmpty() bool {
-	return y.nilIsEmpty
-}
-
 func (y Location) GetId() string {
 	if y.Id != nil {
 		return *y.Id

--- a/location.go
+++ b/location.go
@@ -159,6 +159,10 @@ type Location struct {
 	*/
 }
 
+func (y Location) GetNilIsEmpty() bool {
+	return y.nilIsEmpty
+}
+
 func (y Location) GetId() string {
 	if y.Id != nil {
 		return *y.Id

--- a/location_diff.go
+++ b/location_diff.go
@@ -88,7 +88,7 @@ func (y Location) Diff(b *Location) (d *Location, diff bool) {
 							diff = true
 							d.CustomFields[field] = value
 						}
-					} else if !(isZeroValue(reflect.ValueOf(value), b.GetNilIsEmpty()) && y.nilIsEmpty) {
+					} else if !(isZeroValue(reflect.ValueOf(value), b.nilIsEmpty) && y.nilIsEmpty) {
 						d.CustomFields[field] = value
 						diff = true
 					}

--- a/location_diff.go
+++ b/location_diff.go
@@ -88,7 +88,7 @@ func (y Location) Diff(b *Location) (d *Location, diff bool) {
 							diff = true
 							d.CustomFields[field] = value
 						}
-					} else if !isZeroValue(reflect.ValueOf(value), b.GetNilIsEmpty()) {
+					} else if !(isZeroValue(reflect.ValueOf(value), b.GetNilIsEmpty()) && y.nilIsEmpty) {
 						d.CustomFields[field] = value
 						diff = true
 					}
@@ -110,6 +110,10 @@ func (y Location) Diff(b *Location) (d *Location, diff bool) {
 // getUnderlyingValue unwraps a pointer/interface to get the underlying value.
 // If the value is already unwrapped, it returns it as is.
 func getUnderlyingValue(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+
 	rv := reflect.ValueOf(v)
 
 	switch rv.Kind() {

--- a/location_diff.go
+++ b/location_diff.go
@@ -88,7 +88,7 @@ func (y Location) Diff(b *Location) (d *Location, diff bool) {
 							diff = true
 							d.CustomFields[field] = value
 						}
-					} else {
+					} else if !isZeroValue(reflect.ValueOf(value), b.GetNilIsEmpty()) {
 						d.CustomFields[field] = value
 						diff = true
 					}

--- a/location_diff_test.go
+++ b/location_diff_test.go
@@ -1044,19 +1044,19 @@ func (t customFieldsNilIsEmptyTest) formatErrorBase(index int) string {
 
 func TestCustomFieldsNilIsEmptyDiff(t *testing.T) {
 	a, b := *new(Location), new(Location)
-	for i, data := range customFieldsNilIsEmptyTests {
-		a.CustomFields, b.CustomFields = data.baseValue, data.newValue
-		a.nilIsEmpty, b.nilIsEmpty = data.baseNilIsEmpty, data.newNilIsEmpty
+	for i, test := range customFieldsNilIsEmptyTests {
+		a.CustomFields, b.CustomFields = test.baseValue, test.newValue
+		a.nilIsEmpty, b.nilIsEmpty = test.baseNilIsEmpty, test.newNilIsEmpty
 		d, isDiff := a.Diff(b)
-		if isDiff != data.isDiff {
-			t.Errorf("%vExpected diff to be %v\nbut was %v\ndiff struct was %v\n", data.formatErrorBase(i), data.isDiff, isDiff, d)
+		if isDiff != test.isDiff {
+			t.Errorf("%vExpected diff to be %v\nbut was %v\ndiff struct was %v\n", test.formatErrorBase(i), test.isDiff, isDiff, d)
 		}
-		if d == nil && data.expectedFieldValue == nil {
+		if d == nil && test.expectedFieldValue == nil {
 			continue
-		} else if d == nil && data.expectedFieldValue != nil {
-			t.Errorf("%v\ndelta was nil but expected %v\n", data.formatErrorBase(i), data.expectedFieldValue)
-		} else if !reflect.DeepEqual(data.expectedFieldValue, d.CustomFields) {
-			t.Errorf("%v\ndiff was%v\n", data.formatErrorBase(i), d)
+		} else if d == nil && test.expectedFieldValue != nil {
+			t.Errorf("%v\ndelta was nil but expected %v\n", test.formatErrorBase(i), test.expectedFieldValue)
+		} else if !reflect.DeepEqual(test.expectedFieldValue, d.CustomFields) {
+			t.Errorf("%v\ndiff was%v\n", test.formatErrorBase(i), d)
 		}
 	}
 }

--- a/location_diff_test.go
+++ b/location_diff_test.go
@@ -962,6 +962,105 @@ func TestCustomFieldsDiff(t *testing.T) {
 	}
 }
 
+type customFieldsNilIsEmptyTest struct {
+	baseValue          map[string]interface{}
+	baseNilIsEmpty     bool
+	newValue           map[string]interface{}
+	newNilIsEmpty      bool
+	isDiff             bool
+	expectedFieldValue map[string]interface{}
+}
+
+var customFieldsNilIsEmptyTests = []customFieldsNilIsEmptyTest{
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     true,
+		newValue:           map[string]interface{}{"65": ""},
+		newNilIsEmpty:      false,
+		isDiff:             false,
+		expectedFieldValue: nil,
+	},
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     false,
+		newValue:           map[string]interface{}{"65": ""},
+		newNilIsEmpty:      false,
+		isDiff:             true,
+		expectedFieldValue: map[string]interface{}{"65": ""},
+	},
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     true,
+		newValue:           map[string]interface{}{"65": "yext"},
+		newNilIsEmpty:      false,
+		isDiff:             true,
+		expectedFieldValue: map[string]interface{}{"65": "yext"},
+	},
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     true,
+		newValue:           map[string]interface{}{"65": []string{}},
+		newNilIsEmpty:      false,
+		isDiff:             false,
+		expectedFieldValue: nil,
+	},
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     false,
+		newValue:           map[string]interface{}{"65": []string{}},
+		newNilIsEmpty:      false,
+		isDiff:             true,
+		expectedFieldValue: map[string]interface{}{"65": []string{}},
+	},
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     false,
+		newValue:           map[string]interface{}{"65": []string{"ding"}},
+		newNilIsEmpty:      false,
+		isDiff:             true,
+		expectedFieldValue: map[string]interface{}{"65": []string{"ding"}},
+	},
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     true,
+		newValue:           map[string]interface{}{"65": nil},
+		newNilIsEmpty:      false,
+		isDiff:             false,
+		expectedFieldValue: nil,
+	},
+	{
+		baseValue:          map[string]interface{}{},
+		baseNilIsEmpty:     false,
+		newValue:           map[string]interface{}{"65": nil},
+		newNilIsEmpty:      false,
+		isDiff:             true,
+		expectedFieldValue: map[string]interface{}{"65": nil},
+	},
+}
+
+func (t customFieldsNilIsEmptyTest) formatErrorBase(index int) string {
+	return fmt.Sprintf("Failure with example %v:\n\tbase: '%v'\n\tnew: '%v'", index, t.baseValue, t.newValue)
+}
+
+func TestCustomFieldsNilIsEmptyDiff(t *testing.T) {
+	a, b := *new(Location), new(Location)
+	for i, data := range customFieldsNilIsEmptyTests {
+		a.CustomFields, b.CustomFields = data.baseValue, data.newValue
+		a.nilIsEmpty, b.nilIsEmpty = data.baseNilIsEmpty, data.newNilIsEmpty
+		d, isDiff := a.Diff(b)
+		if isDiff != data.isDiff {
+			t.Errorf("%vExpected diff to be %v\nbut was %v\ndiff struct was %v\n", data.formatErrorBase(i), data.isDiff, isDiff, d)
+		}
+		if d == nil && data.expectedFieldValue == nil {
+			continue
+		} else if d == nil && data.expectedFieldValue != nil {
+			t.Errorf("%v\ndelta was nil but expected %v\n", data.formatErrorBase(i), data.expectedFieldValue)
+		} else if !reflect.DeepEqual(data.expectedFieldValue, d.CustomFields) {
+			t.Errorf("%v\ndiff was%v\n", data.formatErrorBase(i), d)
+		}
+	}
+}
+
 type closedTest struct {
 	baseValue          *LocationClosed
 	newValue           *LocationClosed


### PR DESCRIPTION
Not sure how to test yet, but for visibility I think this is the last of the duplicate updates.
As we already new, if the custom field is not filled out it is missing from the API response. the diff assumes that if the custom field is not there that it is a delta...but if the value is the nil value then there should be no delta.

You can see this in the pf changs database when we've been sending "" daily for single line text fields (p.f. chang's is ignore history so it compares against the API). 