### PR TITLE
J=PC-37965 add bulk endpoints to license service for v1

### DIFF
--- a/license.go
+++ b/license.go
@@ -1,9 +1,9 @@
 package yext
 
 type LicensePack struct {
-	LocationIds []string `json:"locationIds"`
-	Features    []string `json:"features"`
-	Id          int      `json:"id"`
-	Quantity    int      `json:"quantity"`
-	Status      string   `json:"status"`
+	LocationIds []string `json:"locationIds,omitempty"`
+	Features    []string `json:"features,omitempty"`
+	Id          int      `json:"id,omitempty"`
+	Quantity    int      `json:"quantity,omitempty"`
+	Status      string   `json:"status,omitempty"`
 }

--- a/license_service.go
+++ b/license_service.go
@@ -20,8 +20,24 @@ func (l *LicenseService) AddLocationToLicense(licenseId string, locationId strin
 	return &v, err
 }
 
+func (l *LicenseService) AddLocationsToLicenseBulk(licenseId string, locationIds []string) (*LicensePack, error) {
+	v := LicensePack{
+		LocationIds: locationIds,
+	}
+	err := l.client.DoRequest("PUT", fmt.Sprintf("%s/%s/bulk", licensePacksPath, licenseId), &v)
+	return &v, err
+}
+
 func (l *LicenseService) RemoveLocationFromLicense(licenseId string, locationId string) (*LicensePack, error) {
 	var v LicensePack
 	err := l.client.DoRequest("DELETE", fmt.Sprintf("%s/%s/locationIds/%s", licensePacksPath, licenseId, locationId), &v)
+	return &v, err
+}
+
+func (l *LicenseService) RemoveLocationsFromLicenseBulk(licenseId string, locationIds []string) (*LicensePack, error) {
+	v := LicensePack{
+		LocationIds: locationIds,
+	}
+	err := l.client.DoRequest("DELETE", fmt.Sprintf("%s/%s/bulk", licensePacksPath, licenseId), &v)
 	return &v, err
 }

--- a/license_service.go
+++ b/license_service.go
@@ -21,11 +21,12 @@ func (l *LicenseService) AddLocationToLicense(licenseId string, locationId strin
 }
 
 func (l *LicenseService) AddLocationsToLicenseBulk(licenseId string, locationIds []string) (*LicensePack, error) {
+	var w LicensePack
 	v := LicensePack{
 		LocationIds: locationIds,
 	}
-	err := l.client.DoRequest("PUT", fmt.Sprintf("%s/%s/bulk", licensePacksPath, licenseId), &v)
-	return &v, err
+	err := l.client.DoRequestJSON("PUT", fmt.Sprintf("%s/%s/bulk", licensePacksPath, licenseId), &v, &w)
+	return &w, err
 }
 
 func (l *LicenseService) RemoveLocationFromLicense(licenseId string, locationId string) (*LicensePack, error) {
@@ -35,9 +36,10 @@ func (l *LicenseService) RemoveLocationFromLicense(licenseId string, locationId 
 }
 
 func (l *LicenseService) RemoveLocationsFromLicenseBulk(licenseId string, locationIds []string) (*LicensePack, error) {
+	var w LicensePack
 	v := LicensePack{
 		LocationIds: locationIds,
 	}
-	err := l.client.DoRequest("DELETE", fmt.Sprintf("%s/%s/bulk", licensePacksPath, licenseId), &v)
-	return &v, err
+	err := l.client.DoRequestJSON("DELETE", fmt.Sprintf("%s/%s/bulk", licensePacksPath, licenseId), &v, &w)
+	return &w, err
 }


### PR DESCRIPTION
Here is a gist (dev account) with the request body as locationIds https://gist.github.com/cdworak/6c71dad906ce45540023d2635b2eb713

from postman both puts and deletes work with this format. (I cut it down to 3 locations for simplicity).
https://www.yext.com/s/703630/subscriptions/licenseHistory?locationId=0B3192
