### PR TITLE
Hard-encode all requests to the yext api for # characters

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -97,6 +98,7 @@ func (c *Client) NewRootRequestJSON(method string, path string, obj interface{})
 }
 
 func (c *Client) NewRequestBody(method string, fullPath string, data []byte) (*http.Request, error) {
+	fullPath = strings.Replace(fullPath, "#", "%23", -1)
 	req, err := http.NewRequest(method, fullPath, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The reason we can't use the url package is that the # character is a reserved character for URLs. There are others that can be viewed here https://www.lifewire.com/encoding-urls-3467463. That is the reason for hardcoding the encoded value for the # character. Going forward if we don't like using this hack it might make the most sense to tell clients not to use reserved url characters in their ids.