### PR TITLE
Remove references to upper-snake-case entity types

### DIFF
--- a/entity_healthcare_professional.go
+++ b/entity_healthcare_professional.go
@@ -11,11 +11,10 @@ import (
 )
 
 const (
-	ENTITYTYPE_HEALTHCAREPROFESSIONAL    EntityType = "healthcareProfessional"
-	ENTITYTYPE_HEALTHCAREPROFESSIONAL_CF EntityType = "HEALTHCARE_PROFESSIONAL"
-	GENDER_MALE                                     = "MALE"
-	GENDER_FEMALE                                   = "FEMALE"
-	GENDER_UNSPECIFIED                              = "UNSPECIFIED"
+	ENTITYTYPE_HEALTHCAREPROFESSIONAL EntityType = "healthcareProfessional"
+	GENDER_MALE                                  = "MALE"
+	GENDER_FEMALE                                = "FEMALE"
+	GENDER_UNSPECIFIED                           = "UNSPECIFIED"
 )
 
 type HealthcareProfessionalEntity struct {

--- a/entity_location.go
+++ b/entity_location.go
@@ -11,11 +11,6 @@ import (
 
 const ENTITYTYPE_LOCATION EntityType = "location"
 
-// Entity types for custom fields must be MACRO_CASED
-// TODO: wait for completion of this item: https://yexttest.atlassian.net/browse/AO-3660 (ETC End of February 2019)
-// After item is copmleted up the vparam and (hopefully) delete this line and remove all references to it.
-const ENTITYTYPE_LOCATION_CF EntityType = "LOCATION"
-
 // Location is the representation of a Location in Yext Location Manager.
 // For details see https://www.yext.com/support/platform-api/#Administration_API/Locations.htm
 type LocationEntity struct {


### PR DESCRIPTION
Done following Product update that has made entity types
returned from the CF endpoint camel case for consistency
with the entities API