### PR TITLE
Raw entity

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -114,7 +114,11 @@ func (r *RawEntity) GetEntityType() EntityType {
 	if m, ok := (*r)["meta"]; ok {
 		meta := m.(map[string]interface{})
 		if t, ok := meta["entityType"]; ok {
-			return EntityType(t.(string))
+			if s, isString := t.(string); isString {
+				return EntityType(s)
+			} else if _, isEntityType := t.(EntityType); isEntityType {
+				return t.(EntityType)
+			}
 		}
 	}
 	return EntityType("")

--- a/entity_diff.go
+++ b/entity_diff.go
@@ -202,9 +202,9 @@ func RawEntityDiff(a map[string]interface{}, b map[string]interface{}, nilIsEmpt
 			_, aIsMap := aVal.(map[string]interface{})
 			_, bIsMap := aVal.(map[string]interface{})
 			if aIsMap && bIsMap {
-				d, isD := RawEntityDiff(aVal.(map[string]interface{}), bVal.(map[string]interface{}), nilIsEmptyA, nilIsEmptyB)
-				if isD {
-					delta[key] = d
+				subFieldsDelta, subFieldsAreDiff := RawEntityDiff(aVal.(map[string]interface{}), bVal.(map[string]interface{}), nilIsEmptyA, nilIsEmptyB)
+				if subFieldsAreDiff {
+					delta[key] = subFieldsDelta
 					isDiff = true
 				}
 			} else {

--- a/entity_diff.go
+++ b/entity_diff.go
@@ -200,7 +200,7 @@ func RawEntityDiff(a map[string]interface{}, b map[string]interface{}, nilIsEmpt
 		}
 		if aVal, ok := aAsMap[key]; ok {
 			_, aIsMap := aVal.(map[string]interface{})
-			_, bIsMap := aVal.(map[string]interface{})
+			_, bIsMap := bVal.(map[string]interface{})
 			if aIsMap && bIsMap {
 				subFieldsDelta, subFieldsAreDiff := RawEntityDiff(aVal.(map[string]interface{}), bVal.(map[string]interface{}), nilIsEmptyA, nilIsEmptyB)
 				if subFieldsAreDiff {

--- a/entity_diff.go
+++ b/entity_diff.go
@@ -167,9 +167,56 @@ func Diff(a Entity, b Entity) (Entity, bool, error) {
 		return nil, true, fmt.Errorf("Entity Types do not match: '%s', '%s'", a.GetEntityType(), b.GetEntityType())
 	}
 
+	// TODO (cdworak): GenericDiff cannot handle map (RawEntity is map)
+	rawA, okA := a.(*RawEntity)
+	rawB, okB := b.(*RawEntity)
+	if okA && okB {
+		delta, isDiff := RawEntityDiff(*rawA, *rawB, GetNilIsEmpty(a), GetNilIsEmpty(b))
+		if !isDiff {
+			return nil, isDiff, nil
+		}
+		rawDelta := RawEntity(delta)
+		return &rawDelta, isDiff, nil
+	}
+
 	delta, isDiff := GenericDiff(a, b, GetNilIsEmpty(a), GetNilIsEmpty(b))
 	if !isDiff {
 		return nil, isDiff, nil
 	}
 	return delta.(Entity), isDiff, nil
+}
+
+func RawEntityDiff(a map[string]interface{}, b map[string]interface{}, nilIsEmptyA bool, nilIsEmptyB bool) (map[string]interface{}, bool) {
+	var (
+		aAsMap = a
+		bAsMap = b
+		delta  = map[string]interface{}{}
+		isDiff = false
+	)
+
+	for key, bVal := range bAsMap {
+		if key == "nilIsEmpty" {
+			continue
+		}
+		if aVal, ok := aAsMap[key]; ok {
+			_, aIsMap := aVal.(map[string]interface{})
+			_, bIsMap := aVal.(map[string]interface{})
+			if aIsMap && bIsMap {
+				d, isD := RawEntityDiff(aVal.(map[string]interface{}), bVal.(map[string]interface{}), nilIsEmptyA, nilIsEmptyB)
+				if isD {
+					delta[key] = d
+					isDiff = true
+				}
+			} else {
+				if !reflect.DeepEqual(aVal, bVal) {
+					delta[key] = bVal
+					isDiff = true
+				}
+			}
+		}
+	}
+	if isDiff {
+		return delta, true
+	}
+	return nil, false
 }

--- a/entity_diff_test.go
+++ b/entity_diff_test.go
@@ -2406,6 +2406,70 @@ func TestEntityDiffComplex(t *testing.T) {
 	}
 }
 
+func TestRawEntityDiff(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   *RawEntity
+		new    *RawEntity
+		isDiff bool
+		delta  *RawEntity
+	}{
+		{
+			name: "equal",
+			base: &RawEntity{
+				"name": "yext",
+			},
+			new: &RawEntity{
+				"name": "yext",
+			},
+			isDiff: false,
+		},
+		{
+			name: "not equal",
+			base: &RawEntity{
+				"name": String("yext"),
+			},
+			new: &RawEntity{
+				"name": "new yext",
+			},
+			isDiff: true,
+			delta: &RawEntity{
+				"name": "new yext",
+			},
+		},
+		{
+			name: "field within field equal",
+			base: &RawEntity{
+				"meta": map[string]interface{}{
+					"entityType": "location",
+				},
+			},
+			new: &RawEntity{
+				"meta": map[string]interface{}{
+					"entityType": "location",
+				},
+			},
+			isDiff: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			delta, isDiff, _ := Diff(test.base, test.new)
+			if isDiff != test.isDiff {
+				t.Log(delta)
+				t.Errorf("Expected isDiff: %t.\nGot: %t", test.isDiff, isDiff)
+			} else if test.isDiff == false && delta != nil {
+				t.Errorf("Expected isDiff: %t.\nGot delta: %v", test.isDiff, delta)
+			} else if isDiff {
+				if !reflect.DeepEqual(delta, test.delta) {
+					t.Errorf("Expected delta: %v.\nGot: %v", test.delta, delta)
+				}
+			}
+		})
+	}
+}
+
 func TestInstanceOf(t *testing.T) {
 	var (
 		b = String("apple")


### PR DESCRIPTION
The current yext.Diff() function cannot handle a map, only a struct. After attempting to add map functionality the yext.Diff() in the interest of time and simplicity I decided to write something specific for the RawEntity (which is a map). In the future, would be nice to have yext.Diff() automatically handle a map but would require a significant lift as the for loop within yext.Diff is entirely specific to a struct