### PR TITLE
analytics_service: Update Folder IDs filter to match API

### DIFF
--- a/analytics_service.go
+++ b/analytics_service.go
@@ -10,7 +10,7 @@ type AnalyticsFilters struct {
 	StartDate                  *string   `json:"startDate"`
 	EndDate                    *string   `json:"endDate"`
 	LocationIds                *[]string `json:"locationIds"`
-	FolderId                   *int      `json:"folderId"`
+	FolderIds                  *[]int    `json:"folderIds"`
 	Countries                  *[]string `json:"countries"`
 	LocationLabels             *[]string `json:"locationLabels"`
 	Platforms                  *[]string `json:"platforms"`


### PR DESCRIPTION
Looks like the folderId filter changed to folderIds to allow for an array of folders
https://developer.yext.com/docs/api-reference/#operation/createReports