### PR TITLE
fixes bug in rawEntityIsZeroValue

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -166,9 +166,13 @@ func rawEntityIsZeroValue(rawEntity interface{}) bool {
 				// if v is a map or a slice, it means we've got a nested field,
 				// so we need to recurse to check the subfields of it too
 				if mapSubfield, ok := v.(map[string]interface{}); ok {
-					return rawEntityIsZeroValue(mapSubfield)
+					if !rawEntityIsZeroValue(mapSubfield) {
+						return false
+					}
 				} else if sliceSubfield, ok := v.([]interface{}); ok {
-					return rawEntityIsZeroValue(sliceSubfield)
+					if !rawEntityIsZeroValue(sliceSubfield) {
+						return false
+					}
 				} else {
 					// if the value we're looking at isn't nil AND isn't a map or slice (nested field), we can assume
 					// this field on the raw entity has some value, therefore the whole entity is not zero value

--- a/entity_test.go
+++ b/entity_test.go
@@ -687,6 +687,26 @@ func TestRawEntityIsZeroValue(t *testing.T) {
 			},
 			Want: false,
 		},
+		{
+			Name: "Disney ETL Test that was failing",
+			Raw: &RawEntity{
+				"c_oSID":         "80007922",
+				"c_propertyType": "land",
+				"c_storeName":    "frontierland",
+				"description":    "",
+				"hours":          map[string]interface{}{},
+				"meta": map[string]interface{}{
+					"entityType": "location",
+					"id":         "80007922;entityType=land",
+					"labels": []interface{}{
+						"83533",
+					},
+				},
+				"name":         "Frontierland",
+				"photoGallery": []interface{}{},
+			},
+			Want: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
huge miss on my part - previously, if the function encountered a subfield that had zero value, it would just return true on the spot. our break case is if we find something that ISN'T zero value, so instead we need to make sure we actually check all the fields before returning true