### PR TITLE
nil platform bool != zero value

### DIFF
--- a/entity_diff_test.go
+++ b/entity_diff_test.go
@@ -347,7 +347,8 @@ func TestEntityDiff(t *testing.T) {
 			baseValue:      nil,
 			newValue:       NullableBool(false),
 			baseNilIsEmpty: true,
-			isDiff:         false,
+			isDiff:         true,
+			deltaValue:     NullableBool(false),
 		},
 		diffTest{
 			name:           "**Bool: base is nil (nil is empty), new is zero value (nil is empty) (L)",
@@ -356,7 +357,8 @@ func TestEntityDiff(t *testing.T) {
 			newValue:       NullableBool(false),
 			baseNilIsEmpty: true,
 			newNilIsEmpty:  true,
-			isDiff:         false,
+			isDiff:         true,
+			deltaValue:     NullableBool(false),
 		},
 		diffTest{
 			name:          "**Bool: base is zero value, new is nil (nil is empty) (L)",

--- a/entity_diff_test.go
+++ b/entity_diff_test.go
@@ -341,6 +341,7 @@ func TestEntityDiff(t *testing.T) {
 			newValue:  nil,
 			isDiff:    false,
 		},
+		// tests K & L differ from similar tests for other types, since nil isn't the zero value for booleans
 		diffTest{
 			name:           "**Bool: base is nil (nil is empty), new is zero value (K)",
 			property:       "Closed",

--- a/location_diff.go
+++ b/location_diff.go
@@ -149,6 +149,7 @@ func IsZeroValue(v reflect.Value, interpretNilAsZeroValue bool) bool {
 	case reflect.Ptr, reflect.Interface:
 		isNil := v.IsNil()
 		if isNil && v.Type() == reflect.TypeOf((**bool)(nil)) {
+			// nil booleans represent a non-zero value in the platform ("Unspecified" / unset)
 			return false
 		}
 		if isNil && !interpretNilAsZeroValue {

--- a/location_diff.go
+++ b/location_diff.go
@@ -147,7 +147,11 @@ func IsZeroValue(v reflect.Value, interpretNilAsZeroValue bool) bool {
 	case reflect.Float64:
 		return v.Float() == 0.0
 	case reflect.Ptr, reflect.Interface:
-		if v.IsNil() && !interpretNilAsZeroValue {
+		isNil := v.IsNil()
+		if isNil && v.Type() == reflect.TypeOf((**bool)(nil)) {
+			return false
+		}
+		if isNil && !interpretNilAsZeroValue {
 			return false
 		}
 		return IsZeroValue(v.Elem(), true) // Needs to be true for case of double pointer **Hours where **Hours is nil (we want this to be zero)


### PR DESCRIPTION
when dealing with yes/no fields in the Yext platform, there is also an unspecified value (null). This change accounts for cases where we want to set that unspecified value to 'No'