### PR TITLE
add rendered option for entity language profiles

### DIFF
--- a/entity_service.go
+++ b/entity_service.go
@@ -43,6 +43,7 @@ type EntityListOptions struct {
 	ListOptions
 	SearchIDs           []string
 	ResolvePlaceholders bool
+	Rendered            bool // will return resolved placeholders for language profiles
 	EntityTypes         []string
 	Fields              []string
 	Filter              string
@@ -199,6 +200,9 @@ func addEntityListOptions(requrl string, opts *EntityListOptions) (string, error
 	}
 	if opts.ResolvePlaceholders {
 		q.Add("resolvePlaceholders", "true")
+	}
+	if opts.Rendered {
+		q.Add("rendered", "true")
 	}
 	if len(opts.EntityTypes) > 0 {
 		q.Add("entityTypes", strings.Join(opts.EntityTypes, ","))

--- a/entity_service_test.go
+++ b/entity_service_test.go
@@ -57,6 +57,7 @@ func TestEntityListOptions(t *testing.T) {
 		searchIDs           string
 		entityTypes         string
 		resolvePlaceholders bool
+		rendered            bool
 		filter              string
 		format              string
 	}{
@@ -141,6 +142,14 @@ func TestEntityListOptions(t *testing.T) {
 			filter:    "",
 			format:    "none",
 		},
+		{
+			opts:      &EntityListOptions{Rendered: true},
+			limit:     "",
+			token:     "",
+			searchIDs: "",
+			rendered:  true,
+			filter:    "",
+		},
 	}
 
 	for _, test := range tests {
@@ -161,6 +170,10 @@ func TestEntityListOptions(t *testing.T) {
 			v := r.URL.Query().Get("resolvePlaceholders")
 			if v == "true" && !test.resolvePlaceholders || v == "" && test.resolvePlaceholders || v == "false" && test.resolvePlaceholders {
 				t.Errorf("Wanted resolvePlaceholders %t, got %s", test.resolvePlaceholders, v)
+			}
+			v = r.URL.Query().Get("rendered")
+			if v == "true" && !test.rendered || v == "" && test.rendered || v == "false" && test.rendered {
+				t.Errorf("Wanted rendered %t, got %s", test.rendered, v)
 			}
 			if v := r.URL.Query().Get("filter"); v != test.filter {
 				t.Errorf("Wanted filter %s, got %s", test.filter, v)


### PR DESCRIPTION
For alternative language profiles, we need to pass `rendered=true` to retrieve resolved embedded fields. Currently, we're using `resolvePlaceholder` in [entity.go](https://gerrit.yext.com/plugins/gitiles/congo/+/refs/heads/master/yext/account/entity.go#67), which is only valid parameter for the `/entities` endpoint, not `/entityprofiles`.