### PR TITLE
added option to consider nil booleans as non-zero values

### DIFF
--- a/cftasset_diff.go
+++ b/cftasset_diff.go
@@ -13,7 +13,7 @@ func (a *CFTAsset) Diff(b *CFTAsset) (*CFTAsset, bool) {
 		return nil, true
 	}
 
-	delta, isDiff := GenericDiff(a, b, true, true)
+	delta, isDiff := GenericDiff(a, b, true, true, true, true)
 	if !isDiff {
 		return nil, isDiff
 	}

--- a/client.go
+++ b/client.go
@@ -69,9 +69,9 @@ func NewClient(config *Config) *Client {
 	c.CFTAssetService.RegisterDefaultAssetValues()
 	c.ActivityLogService = &ActivityLogService{client: c}
 	c.AnalyticsService = &AnalyticsService{client: c}
-	c.EntityService = &EntityService{client: c}
+	c.EntityService = &EntityService{client: c, nilBoolIsEmpty: true}
 	c.EntityService.RegisterDefaultEntities()
-	c.LanguageProfileService = &LanguageProfileService{client: c}
+	c.LanguageProfileService = &LanguageProfileService{client: c, nilBoolIsEmpty: true}
 	c.AccountService = &AccountService{client: c}
 	c.ServicesService = &ServicesService{client: c}
 	c.LanguageProfileService.RegisterDefaultEntities()

--- a/entity.go
+++ b/entity.go
@@ -22,8 +22,9 @@ type EntityMeta struct {
 }
 
 type BaseEntity struct {
-	Meta       *EntityMeta `json:"meta,omitempty"`
-	nilIsEmpty bool
+	Meta           *EntityMeta `json:"meta,omitempty"`
+	nilIsEmpty     bool
+	nilBoolIsEmpty bool
 }
 
 func (b *BaseEntity) GetEntityId() string {
@@ -94,8 +95,16 @@ func (b *BaseEntity) GetNilIsEmpty() bool {
 	return b.nilIsEmpty
 }
 
+func (b *BaseEntity) GetNilBoolIsEmpty() bool {
+	return b.nilBoolIsEmpty
+}
+
 func (b *BaseEntity) SetNilIsEmpty(val bool) {
 	b.nilIsEmpty = val
+}
+
+func (b *BaseEntity) SetNilBoolIsEmpty(val bool) {
+	b.nilBoolIsEmpty = val
 }
 
 type RawEntity map[string]interface{}

--- a/entity_diff_test.go
+++ b/entity_diff_test.go
@@ -6,14 +6,16 @@ import (
 )
 
 type diffTest struct {
-	name           string
-	property       string
-	isDiff         bool
-	baseValue      interface{}
-	newValue       interface{}
-	baseNilIsEmpty bool
-	newNilIsEmpty  bool
-	deltaValue     interface{}
+	name               string
+	property           string
+	isDiff             bool
+	baseValue          interface{}
+	newValue           interface{}
+	baseNilIsEmpty     bool
+	newNilIsEmpty      bool
+	baseNilBoolIsEmpty bool
+	newNilBoolIsEmpty  bool
+	deltaValue         interface{}
 }
 
 func setValOnProperty(val interface{}, property string, entity Entity) {
@@ -342,38 +344,59 @@ func TestEntityDiff(t *testing.T) {
 			isDiff:    false,
 		},
 		diffTest{
-			name:           "**Bool: base is nil (nil is empty), new is zero value (K)",
-			property:       "Closed",
-			baseValue:      nil,
-			newValue:       NullableBool(false),
-			baseNilIsEmpty: true,
-			isDiff:         false,
+			name:               "**Bool: base is nil (nil is empty), new is zero value (K)",
+			property:           "Closed",
+			baseValue:          nil,
+			newValue:           NullableBool(false),
+			baseNilIsEmpty:     true,
+			baseNilBoolIsEmpty: true,
+			newNilBoolIsEmpty:  true,
+			isDiff:             false,
 		},
 		diffTest{
-			name:           "**Bool: base is nil (nil is empty), new is zero value (nil is empty) (L)",
-			property:       "Closed",
-			baseValue:      nil,
-			newValue:       NullableBool(false),
-			baseNilIsEmpty: true,
-			newNilIsEmpty:  true,
-			isDiff:         false,
+			name:               "**Bool: base is nil (nil is empty), new is zero value (nil is empty) (L)",
+			property:           "Closed",
+			baseValue:          nil,
+			newValue:           NullableBool(false),
+			baseNilIsEmpty:     true,
+			newNilIsEmpty:      true,
+			baseNilBoolIsEmpty: true,
+			newNilBoolIsEmpty:  true,
+			isDiff:             false,
 		},
 		diffTest{
-			name:          "**Bool: base is zero value, new is nil (nil is empty) (L)",
-			property:      "Closed",
-			baseValue:     NullableBool(false),
-			newValue:      nil,
-			newNilIsEmpty: true,
-			isDiff:        false,
+			name:               "**Bool: base is zero value, new is nil (nil is empty) (L)",
+			property:           "Closed",
+			baseValue:          NullableBool(false),
+			newValue:           nil,
+			newNilIsEmpty:      true,
+			baseNilBoolIsEmpty: true,
+			newNilBoolIsEmpty:  true,
+			isDiff:             false,
 		},
 		diffTest{
-			name:           "**Bool: base is zero value (nil is empty), new is nil (nil is empty) (L)",
-			property:       "Closed",
-			baseValue:      NullableBool(false),
-			newValue:       nil,
-			baseNilIsEmpty: true,
-			newNilIsEmpty:  true,
-			isDiff:         false,
+			name:               "**Bool: base is zero value (nil is empty), new is nil (nil is empty) (L)",
+			property:           "Closed",
+			baseValue:          NullableBool(false),
+			newValue:           nil,
+			baseNilIsEmpty:     true,
+			newNilIsEmpty:      true,
+			baseNilBoolIsEmpty: true,
+			newNilBoolIsEmpty:  true,
+			isDiff:             false,
+		},
+		// test M differ from similar tests for other types, as it doesn't consider nil to be the zero value
+		diffTest{
+			name:               "**Bool: base is nil (nil is empty), new is zero value (M)",
+			property:           "Closed",
+			baseValue:          nil,
+			newValue:           NullableBool(false),
+			baseNilIsEmpty:     true,
+			newNilIsEmpty:      true,
+			baseNilBoolIsEmpty: false,
+			newNilBoolIsEmpty:  false,
+			isDiff:             true,
+			deltaValue:         NullableBool(false),
 		},
 		// Struct tests (Address)
 		diffTest{
@@ -828,6 +851,12 @@ func TestEntityDiff(t *testing.T) {
 			}
 			if test.newNilIsEmpty {
 				setNilIsEmpty(newEntity)
+			}
+			if test.baseNilBoolIsEmpty {
+				setNilBoolIsEmpty(baseEntity)
+			}
+			if test.newNilBoolIsEmpty {
+				setNilBoolIsEmpty(newEntity)
 			}
 			delta, isDiff, _ := Diff(baseEntity, newEntity)
 			if isDiff != test.isDiff {

--- a/entity_test.go
+++ b/entity_test.go
@@ -804,7 +804,7 @@ func TestSetValue(t *testing.T) {
 		if err != nil {
 			t.Errorf("Got err: %s", err)
 		}
-		if delta, isDiff := RawEntityDiff(*test.Raw, *test.Want, false, false); isDiff {
+		if delta, isDiff := RawEntityDiff(*test.Raw, *test.Want, false, false, false, false); isDiff {
 			t.Errorf("Got: %v, Wanted: %v, Delta: %v", test.Raw, test.Want, delta)
 		}
 	}

--- a/language_profile_service.go
+++ b/language_profile_service.go
@@ -11,8 +11,9 @@ const (
 )
 
 type LanguageProfileService struct {
-	client   *Client
-	registry *EntityRegistry
+	client         *Client
+	registry       *EntityRegistry
+	nilBoolIsEmpty bool
 }
 
 type LanguageProfileListResponse struct {
@@ -48,6 +49,9 @@ func (l *LanguageProfileService) Get(id string, languageCode string) (*Entity, *
 		return nil, r, err
 	}
 	setNilIsEmpty(entity)
+	if l.nilBoolIsEmpty {
+		setNilBoolIsEmpty(entity)
+	}
 
 	return &entity, r, nil
 }
@@ -68,6 +72,9 @@ func (l *LanguageProfileService) List(id string) ([]Entity, *Response, error) {
 	}
 	for _, profile := range typedProfiles {
 		setNilIsEmpty(profile)
+		if l.nilBoolIsEmpty {
+			setNilBoolIsEmpty(profile)
+		}
 		profiles = append(profiles, profile)
 	}
 	return profiles, r, nil
@@ -138,6 +145,9 @@ func (l *LanguageProfileService) listAllHelper(opts *EntityListOptions) (*Langua
 
 	for _, entity := range typedEntities {
 		setNilIsEmpty(entity)
+		if l.nilBoolIsEmpty {
+			setNilBoolIsEmpty(entity)
+		}
 	}
 
 	v.typedProfiles = typedEntities
@@ -181,4 +191,8 @@ func (l *LanguageProfileService) Delete(id string, languageCode string) (*Respon
 		return r, err
 	}
 	return r, nil
+}
+
+func (l *LanguageProfileService) SetNilBoolIsEmpty(nilBoolIsEmpty bool) {
+	l.nilBoolIsEmpty = nilBoolIsEmpty
 }

--- a/location.go
+++ b/location.go
@@ -34,8 +34,9 @@ type Location struct {
 	Language     *string                `json:"language,omitempty"`
 	CustomFields map[string]interface{} `json:"customFields,omitempty"`
 
-	hydrated   bool
-	nilIsEmpty bool
+	hydrated       bool
+	nilIsEmpty     bool
+	nilBoolIsEmpty bool
 
 	// Address Fields
 	Name            *string `json:"locationName,omitempty"`

--- a/location_diff_test.go
+++ b/location_diff_test.go
@@ -1579,10 +1579,11 @@ func TestHoursAreEquivalentDiff(t *testing.T) {
 
 func TestIsZeroValue(t *testing.T) {
 	tests := []struct {
-		name       string
-		i          interface{}
-		nilIsEmpty bool
-		want       bool
+		name           string
+		i              interface{}
+		nilIsEmpty     bool
+		nilBoolIsEmpty bool
+		want           bool
 	}{
 		{
 			name: "Non-Empty String",
@@ -1738,7 +1739,7 @@ func TestIsZeroValue(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if isZeroValue := IsZeroValue(reflect.ValueOf(test.i), test.nilIsEmpty); test.want != isZeroValue {
+			if isZeroValue := IsZeroValue(reflect.ValueOf(test.i), test.nilIsEmpty, test.nilBoolIsEmpty); test.want != isZeroValue {
 				t.Errorf(`Expected IsZeroValue: %t\nGot:%t`, test.want, isZeroValue)
 			}
 		})


### PR DESCRIPTION
when nilIsEmpty is set to true, the differ considers nil booleans as the zero value ("false"). This commit introduces nilBoolIsEmpty, a flag specifically for booleans that can override nilIsEmpty