### PR TITLE
Update Financial Professional Field types 

### DIFF
--- a/entity_financial_professional.go
+++ b/entity_financial_professional.go
@@ -60,10 +60,10 @@ type FinancialProfessional struct {
 	OrderUrl        **Website         `json:"orderUrl,omitempty"`
 	ReservationUrl  **Website         `json:"reservationUrl,omitempty"`
 	WebsiteUrl      **Website         `json:"websiteUrl,omitempty"`
-	LandingPageUrl  **Website         `json:"landingPageUrl,omitempty"`
-	IOSAppURL       **Website         `json:"iosAppUrl,omitempty"`
-	AndroidAppURL   **Website         `json:"androidAppUrl,omitempty"`
-	DisclosureLink  **Website         `json:"disclosureLink,omitempty"`
+	LandingPageUrl  *string           `json:"landingPageUrl,omitempty"`
+	IOSAppURL       *string           `json:"iosAppUrl,omitempty"`
+	AndroidAppURL   *string           `json:"androidAppUrl,omitempty"`
+	DisclosureLink  *string           `json:"disclosureLink,omitempty"`
 	FeaturedMessage **FeaturedMessage `json:"featuredMessage,omitempty"`
 
 	// Social Media


### PR DESCRIPTION
Changes DisclosureLink AndroidAppURL IOSAppURL LandingPageUrl to *string types to match what is in platform.

See sample response from sandbox
https://api-sandbox.yext.com/v2/accounts/me/entities/n1529420?v=20190714&api_key=[get key from liberty mutual accnt]